### PR TITLE
Implement Google sign‑in

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -32,6 +32,7 @@ export default {
       firebaseStorageBucket: process.env.FIREBASE_STORAGE_BUCKET ?? "",
       firebaseMessagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID ?? "",
       firebaseAppId: process.env.FIREBASE_APP_ID ?? "",
+      googleWebClientId: process.env.GOOGLE_WEB_CLIENT_ID ?? "",
     }
   }
-}; 
+};

--- a/config/config.ts
+++ b/config/config.ts
@@ -4,6 +4,7 @@ import { initializeAuth, getReactNativePersistence } from 'firebase/auth/react-n
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const RUNPOD_ENDPOINT = Constants.expoConfig?.extra?.runpodEndpoint ?? 'https://u0yfim6wmdb9ov-8000.proxy.runpod.net/';
+export const GOOGLE_WEB_CLIENT_ID = Constants.expoConfig?.extra?.googleWebClientId ?? '';
 
 // Firebase configuration
 const firebaseConfig = {
@@ -24,5 +25,6 @@ export const auth = initializeAuth(app, {
 export const CONFIG = {
   RUNPOD_ENDPOINT,
   firebaseConfig,
+  GOOGLE_WEB_CLIENT_ID,
   // Add other config values as needed
-}; 
+};

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -9,6 +9,7 @@ interface AuthContextType {
   trialMinutesRemaining: number;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string) => Promise<void>;
+  signInWithGoogle: () => Promise<void>;
   signOut: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
   updateProfile: (displayName: string, photoURL?: string) => Promise<void>;
@@ -64,6 +65,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const signInWithGoogle = async () => {
+    try {
+      await authService.signInWithGoogle();
+    } catch (error) {
+      console.error('Google sign-in error:', error);
+      throw error;
+    }
+  };
+
   const signOut = async () => {
     try {
       await authService.signOut();
@@ -112,6 +122,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         trialMinutesRemaining,
         signIn,
         signUp,
+        signInWithGoogle,
         signOut,
         resetPassword,
         updateProfile,

--- a/screens/SignInScreen.tsx
+++ b/screens/SignInScreen.tsx
@@ -1,4 +1,6 @@
 import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
+
 
 export default function SignInScreen({
   visible,
@@ -7,6 +9,16 @@ export default function SignInScreen({
   visible: boolean;
   onClose: () => void;
 }) {
+  const { signInWithGoogle } = useAuth();
+
+  const handleGooglePress = async () => {
+    try {
+      await signInWithGoogle();
+      onClose();
+    } catch (error) {
+      console.error('Google sign-in failed', error);
+    }
+  };
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       {/* Outer pressable catches taps outside the modal */}
@@ -15,7 +27,7 @@ export default function SignInScreen({
         <Pressable style={styles.modal} onPress={() => {}}>
           <Text style={styles.title}>Sign In</Text>
 
-          <Pressable style={styles.google} onPress={() => {}}>
+          <Pressable style={styles.google} onPress={handleGooglePress}>
             <Text style={styles.googleText}>Continue with Google</Text>
           </Pressable>
 


### PR DESCRIPTION
## Summary
- add Google web client ID to Expo config
- expose Google client ID in config helper
- implement `signInWithGoogle` in `authService`
- support Google sign-in from `AuthContext`
- hook up Google sign-in button in `SignInScreen`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843dd1b4ce88328a2733b3f7b47dea3