### PR TITLE
Fix Firebase initialization

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,6 +1,6 @@
 import Constants from 'expo-constants';
-import { initializeApp } from 'firebase/app';
-import { initializeAuth, getReactNativePersistence } from 'firebase/auth/react-native';
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { initializeAuth, getAuth, getReactNativePersistence } from 'firebase/auth/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const RUNPOD_ENDPOINT = Constants.expoConfig?.extra?.runpodEndpoint ?? 'https://u0yfim6wmdb9ov-8000.proxy.runpod.net/';
@@ -16,11 +16,19 @@ const firebaseConfig = {
   appId: Constants.expoConfig?.extra?.firebaseAppId,
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-export const auth = initializeAuth(app, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+// Initialize Firebase only if needed (helps with hot reloads)
+const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
+
+// Ensure Auth is set up with React Native persistence
+let auth;
+try {
+  auth = initializeAuth(app, {
+    persistence: getReactNativePersistence(AsyncStorage),
+  });
+} catch {
+  auth = getAuth(app);
+}
+export { app, auth };
 
 export const CONFIG = {
   RUNPOD_ENDPOINT,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testMatch: ['**/tests/**/*.test.ts'],
+  transform: {},
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,6 @@
+import { app, auth } from '../config/config';
+
+test('firebase initializes', () => {
+  expect(app).toBeDefined();
+  expect(auth).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- avoid duplicate initialization of firebase by checking existing apps
- configure React Native persistence for auth
- add minimal Jest test scaffolding

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ebd0f46083289558b5125f955efe