### PR TITLE
Remove Runpod references

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -87,9 +87,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace 'com.voicesummarizer.app'
+    namespace 'com.voccanote.app'
     defaultConfig {
-        applicationId 'com.voicesummarizer.app'
+        applicationId 'com.voccanote.app'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="com.voicesummarizer.app"/>
+        <data android:scheme="com.voccanote.app"/>
         <data android:scheme="exp+voice-summarizer"/>
       </intent-filter>
     </activity>

--- a/android/app/src/main/java/com/voicesummarizer/app/MainActivity.kt
+++ b/android/app/src/main/java/com/voicesummarizer/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.voicesummarizer.app
+package com.voccanote.app
 
 import android.os.Build
 import android.os.Bundle

--- a/android/app/src/main/java/com/voicesummarizer/app/MainApplication.kt
+++ b/android/app/src/main/java/com/voicesummarizer/app/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.voicesummarizer.app
+package com.voccanote.app
 
 import android.app.Application
 import android.content.res.Configuration

--- a/app.json
+++ b/app.json
@@ -21,7 +21,10 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "host.exp.exponent"
+      "package": "com.voccanote.app"
+    },
+    "ios": {
+      "bundleIdentifier": "com.voccanote.app"
     },
     "web": {
       "favicon": "./assets/favicon.png"
@@ -32,6 +35,7 @@
     ],
     "extra": {
       "router": {},
+      "transcriptionEndpoint": "https://whispercpp-production-9842.up.railway.app",
       "eas": {
         "projectId": "89b077f3-6821-49ea-84ed-030246b56f52"
       }

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,9 +1,9 @@
 import Constants from 'expo-constants';
 
 // ✅ Runtime values from app config
-export const RUNPOD_ENDPOINT =
-  Constants.expoConfig?.extra?.runpodEndpoint ??
-  'https://u0yfim6wmdb9ov-8000.proxy.runpod.net/';
+export const TRANSCRIPTION_ENDPOINT =
+  Constants.expoConfig?.extra?.transcriptionEndpoint ??
+  'https://whispercpp-production-9842.up.railway.app';
 
 // Auth config
 export const AUTH_CONFIG = {
@@ -23,7 +23,7 @@ export const AUTH_CONFIG = {
 
 // ✅ Exports
 export const CONFIG = {
-  RUNPOD_ENDPOINT: process.env.EXPO_PUBLIC_RUNPOD_ENDPOINT,
+  TRANSCRIPTION_ENDPOINT: process.env.EXPO_PUBLIC_TRANSCRIPTION_ENDPOINT,
   OPENAI_API_KEY: process.env.EXPO_PUBLIC_OPENAI_API_KEY,
   AUTH: {
     googleClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,

--- a/eas.json
+++ b/eas.json
@@ -7,13 +7,13 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "RUNPOD_ENDPOINT": "https://whispercpp-production-9842.up.railway.app/"
+        "TRANSCRIPTION_ENDPOINT": "https://whispercpp-production-9842.up.railway.app"
       }
     },
     "preview": {
       "distribution": "internal",
       "env": {
-        "RUNPOD_ENDPOINT": "https://whispercpp-production-9842.up.railway.app/"
+        "TRANSCRIPTION_ENDPOINT": "https://whispercpp-production-9842.up.railway.app"
       }
     },
     "production": {
@@ -24,7 +24,7 @@
         "buildConfiguration": "Release"
       },
       "env": {
-        "RUNPOD_ENDPOINT": "https://whispercpp-production-9842.up.railway.app/"
+        "TRANSCRIPTION_ENDPOINT": "https://whispercpp-production-9842.up.railway.app"
       }
     }
   }

--- a/ios/voicesummarizer.xcodeproj/project.pbxproj
+++ b/ios/voicesummarizer.xcodeproj/project.pbxproj
@@ -257,7 +257,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.voicesummarizer.app";
+                            PRODUCT_BUNDLE_IDENTIFIER = "com.voccanote.app";
 				PRODUCT_NAME = "voicesummarizer";
 				SWIFT_OBJC_BRIDGING_HEADER = "voicesummarizer/voicesummarizer-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -286,7 +286,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.voicesummarizer.app";
+                            PRODUCT_BUNDLE_IDENTIFIER = "com.voccanote.app";
 				PRODUCT_NAME = "voicesummarizer";
 				SWIFT_OBJC_BRIDGING_HEADER = "voicesummarizer/voicesummarizer-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/voicesummarizer.xcodeproj/xcshareddata/xcschemes/voicesummarizer.xcscheme
+++ b/ios/voicesummarizer.xcodeproj/xcshareddata/xcschemes/voicesummarizer.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-               BuildableName = "voicesummarizer.app"
+               BuildableName = "voccanote.app"
                BlueprintName = "voicesummarizer"
                ReferencedContainer = "container:voicesummarizer.xcodeproj">
             </BuildableReference>
@@ -55,7 +55,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "voicesummarizer.app"
+            BuildableName = "voccanote.app"
             BlueprintName = "voicesummarizer"
             ReferencedContainer = "container:voicesummarizer.xcodeproj">
          </BuildableReference>
@@ -72,7 +72,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "voicesummarizer.app"
+            BuildableName = "voccanote.app"
             BlueprintName = "voicesummarizer"
             ReferencedContainer = "container:voicesummarizer.xcodeproj">
          </BuildableReference>

--- a/ios/voicesummarizer/Info.plist
+++ b/ios/voicesummarizer/Info.plist
@@ -27,8 +27,8 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>com.voicesummarizer.app</string>
-          <string>com.voicesummarizer.app</string>
+          <string>com.voccanote.app</string>
+          <string>com.voccanote.app</string>
         </array>
       </dict>
       <dict>

--- a/screens/RecorderScreen.tsx
+++ b/screens/RecorderScreen.tsx
@@ -34,7 +34,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { SubscriptionBanner } from '../components/SubscriptionBanner';
 
-const { RUNPOD_ENDPOINT } = CONFIG;
+const { TRANSCRIPTION_ENDPOINT } = CONFIG;
 
 type RecorderScreenNavigationProp = CompositeNavigationProp<
   BottomTabNavigationProp<TabStackParamList, 'Recorder'>,
@@ -479,7 +479,7 @@ export default function RecorderScreen() {
 
       const token = await trialService.getAuthToken();
       
-      const response = await fetch(RUNPOD_ENDPOINT, {
+      const response = await fetch(TRANSCRIPTION_ENDPOINT, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/services/recordingService.ts
+++ b/services/recordingService.ts
@@ -1,8 +1,9 @@
 import { Audio } from 'expo-av';
 import * as FileSystem from 'expo-file-system';
 import { storageService } from './storageService';
+import { CONFIG } from '../config/config';
 
-const RUNPOD_ENDPOINT = 'https://u0yfim6wmdb9ov-8000.proxy.runpod.net/transcribe';
+const TRANSCRIPTION_ENDPOINT = `${CONFIG.TRANSCRIPTION_ENDPOINT}/transcribe`;
 const CHUNK_DURATION = 3000; // 3 seconds for better transcription
 
 class RecordingService {
@@ -190,7 +191,7 @@ class RecordingService {
       formData.append('task', 'transcribe');
       formData.append('language', 'auto');
 
-      const response = await fetch(RUNPOD_ENDPOINT, {
+      const response = await fetch(TRANSCRIPTION_ENDPOINT, {
         method: 'POST',
         body: formData,
         headers: {


### PR DESCRIPTION
## Summary
- switch Android/iOS package names to `com.voccanote.app`
- stop mentioning Runpod in config and EAS settings
- expose `TRANSCRIPTION_ENDPOINT` runtime variable
- call the new endpoint in recording services

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a4a1afaec8328a3ff9a6b50627507